### PR TITLE
define zend_ce_exception for PHP 5

### DIFF
--- a/phpc.h
+++ b/phpc.h
@@ -161,6 +161,10 @@
 
 #if PHP_MAJOR_VERSION == 5
 
+/* EXCEPTIONS */
+
+#define zend_ce_exception zend_exception_get_default(TSRMLS_C)
+
 /* MODULE */
 
 #ifdef ZTS


### PR DESCRIPTION
As this was added in PHP 7.0

Will be needed for PHP 5, ex https://github.com/php-gnupg/php-gnupg/pull/57